### PR TITLE
Feat case error predicate

### DIFF
--- a/src/case-error.test.ts
+++ b/src/case-error.test.ts
@@ -18,15 +18,15 @@ interface NewTypeOfError {
   type: 'NewTypeOfError';
 }
 
-const isDivisionByZeroError = <E> (err: E | DivisionByZeroError): err is DivisionByZeroError =>
+const isDivisionByZeroError = (err: any): err is DivisionByZeroError =>
   err && (err as any).errorType === 'DivisionByZeroError'
 ;
 
-const isDontLikeEvenNumbersError = <E> (err: E | DontLikeEvenNumbersError): err is DontLikeEvenNumbersError =>
+const isDontLikeEvenNumbersError = (err: any): err is DontLikeEvenNumbersError =>
   err instanceof DontLikeEvenNumbersError;
 ;
 
-const isNewTypeOfError = <E> (err: E | NewTypeOfError): err is NewTypeOfError =>
+const isNewTypeOfError = (err: any): err is NewTypeOfError =>
   err && (err as any).type === 'NewTypeOfError';
 ;
 
@@ -60,7 +60,9 @@ describe('caseError:', () => {
     const task = divideTask(2, 0)
 
     // WHEN: We catch and solve the error
-    const result = task.catch(caseError(isDivisionByZeroError, _ => Task.resolve(-1000)))
+    const result = task
+      .catch(caseError(isDivisionByZeroError, _ => Task.resolve(-1000)))
+    ;
     // THEN: The resulting type doesn't have the catched error as a posibility
     //       and the task is resolved with the catched response
     result.fork(jestAssertUntypedNeverCalled(cb), assertFork(cb, n => expect(n).toBe(-1000)))
@@ -123,7 +125,7 @@ describe('caseError:', () => {
       )
       .catch(
         caseError(
-          <E> (err: E | UncaughtError): err is UncaughtError =>
+          (err: any): err is UncaughtError =>
             err instanceof UncaughtError,
           err =>
             Task.resolve(`Could not compute: UncaughtError ${err}`)

--- a/src/case-error.test.ts
+++ b/src/case-error.test.ts
@@ -2,8 +2,8 @@ import { Task, UncaughtError } from '@ts-task/task';
 import { assertFork, jestAssertNever, jestAssertUntypedNeverCalled } from './testing-utils';
 import { caseError } from './case-error';
 
-class DivisionByZeroError extends Error {
-  private type = 'DivisionByZeroError';
+interface DivisionByZeroError {
+  errorType: 'DivisionByZeroError';
 }
 
 class DontLikeEvenNumbersError extends Error {
@@ -14,14 +14,30 @@ class DontLikeEvenNumbersError extends Error {
   }
 }
 
-class NewTypeOfError extends Error {
-  type = 'NewTypeOfError';
+interface NewTypeOfError {
+  type: 'NewTypeOfError';
 }
+
+const isDivisionByZeroError = <E> (err: E | DivisionByZeroError): err is DivisionByZeroError =>
+  err && (err as any).errorType === 'DivisionByZeroError'
+;
+
+const isDontLikeEvenNumbersError = <E> (err: E | DontLikeEvenNumbersError): err is DontLikeEvenNumbersError =>
+  err instanceof DontLikeEvenNumbersError;
+;
+
+const isNewTypeOfError = <E> (err: E | NewTypeOfError): err is NewTypeOfError =>
+  err && (err as any).type === 'NewTypeOfError';
+;
+
+const divisionByZeroError: DivisionByZeroError = {
+  errorType: 'DivisionByZeroError'
+};
 
 // function divideTask (numerator: number, denominator: number) {
 function divideTask(numerator: number, denominator: number): Task<number, DivisionByZeroError> {
   if (denominator === 0) {
-    return Task.reject(new DivisionByZeroError())
+    return Task.reject(divisionByZeroError)
   } else {
     return Task.resolve(numerator / denominator)
   }
@@ -44,7 +60,7 @@ describe('caseError:', () => {
     const task = divideTask(2, 0)
 
     // WHEN: We catch and solve the error
-    const result = task.catch(caseError(DivisionByZeroError, _ => Task.resolve(-1000)))
+    const result = task.catch(caseError(isDivisionByZeroError, _ => Task.resolve(-1000)))
     // THEN: The resulting type doesn't have the catched error as a posibility
     //       and the task is resolved with the catched response
     result.fork(jestAssertUntypedNeverCalled(cb), assertFork(cb, n => expect(n).toBe(-1000)))
@@ -56,13 +72,15 @@ describe('caseError:', () => {
 
     // WHEN: We catch and reject with a new error
     const result = task.catch(
-      caseError(DivisionByZeroError, _ => Task.reject(new NewTypeOfError()))
+      caseError(isDivisionByZeroError, _ => Task.reject({
+        type: 'NewTypeOfError'
+      } as NewTypeOfError))
     )
     // THEN: The resulting type doesn't have the catched error as a posibility
     //       the resulting type has the new rejected type as a posibility
     //       and the task is rejected with the new error
     result.fork(
-      assertFork(cb, err => expect(err).toBeInstanceOf(NewTypeOfError)),
+      assertFork(cb, err => expect(isNewTypeOfError(err)).toBe(true)),
       jestAssertUntypedNeverCalled(cb)
     )
   })
@@ -73,7 +91,9 @@ describe('caseError:', () => {
 
     // WHEN: We catch the wrong exception trying to reject with a new error
     const result = task.catch(
-      caseError(DivisionByZeroError, _ => Task.reject(new NewTypeOfError()))
+      caseError(isDivisionByZeroError, _ => Task.reject({
+        type: 'NewTypeOfError'
+      } as NewTypeOfError))
     )
     // THEN: The resulting type doesn't have the unmatched error as a posibility
     //       the resulting type has the new rejected type as a posibility
@@ -92,19 +112,24 @@ describe('caseError:', () => {
     const result = task
       .map(n => `The result is ${n}`)
       .catch(
-        caseError(DivisionByZeroError, _ =>
+        caseError(isDivisionByZeroError, _ =>
           Task.resolve('Could not compute: DivisionByZeroError ocurred')
         )
       )
       .catch(
-        caseError(DontLikeEvenNumbersError, _ =>
+        caseError(isDontLikeEvenNumbersError, _ =>
           Task.resolve('Could not compute: DontLikeEvenNumbersError ocurred')
         )
       )
       .catch(
-        caseError(UncaughtError, err => Task.resolve(`Could not compute: UncaughtError ${err}`))
+        caseError(
+          <E> (err: E | UncaughtError): err is UncaughtError =>
+            err instanceof UncaughtError,
+          err =>
+            Task.resolve(`Could not compute: UncaughtError ${err}`)
+        )
       )
-      ;
+    ;
     // THEN: The resulting type doesn't have the catched errors
     //       and the task is resolved with the mapped answer
     result.fork(jestAssertNever(cb), assertFork(cb, s => expect(s).toBe('The result is 5')));
@@ -117,14 +142,14 @@ describe('caseError:', () => {
     // WHEN: We catch an imposible exception
     const result = task.catch(
       caseError(
-        DontLikeEvenNumbersError, // TODO: It would be nice to see this fail compilation as it is not possible that
+        isDontLikeEvenNumbersError, // TODO: It would be nice to see this fail compilation as it is not possible that
         //       task fails with DontLikeEvenNumbersError
         _ => Task.resolve(0)
       )
     )
     // THEN: The task is rejected with the original error
     result.fork(
-      assertFork(cb, err => expect(err).toBeInstanceOf(DivisionByZeroError)),
+      assertFork(cb, err => expect(isDivisionByZeroError(err)).toBe(true)),
       jestAssertUntypedNeverCalled(cb)
     )
   })

--- a/src/case-error.ts
+++ b/src/case-error.ts
@@ -21,3 +21,4 @@ export function caseError<ErrorToHandle, TResult, EResult>(
     }
   }
 }
+

--- a/src/case-error.ts
+++ b/src/case-error.ts
@@ -21,4 +21,3 @@ export function caseError<ErrorToHandle, TResult, EResult>(
     }
   }
 }
-

--- a/src/case-error.ts
+++ b/src/case-error.ts
@@ -1,18 +1,18 @@
-import { Task, UncaughtError } from '@ts-task/task'
-
-export type Constructor<T> = { new (...args: any[]): T }
+import { Task } from '@ts-task/task'
 
 export type ErrorHandler<ErrorToHandle, TResult, EResult> = (err: ErrorToHandle) => Task<TResult, EResult>
 
+export type ErrorPredicate <ErrorToHandle> = <T> (err: T | ErrorToHandle) => err is ErrorToHandle;
+
 export function caseError<ErrorToHandle, TResult, EResult>(
-  ErrorType: Constructor<ErrorToHandle>,
+  errorPredicate: ErrorPredicate<ErrorToHandle>,
   errorHandler: ErrorHandler<ErrorToHandle, TResult, EResult>
 ) {
   return function <InputError> (
     err: InputError | ErrorToHandle
   ): Task<TResult, EResult | Exclude<InputError, ErrorToHandle>> {
     // If the error is of the type we are looking for (E)
-    if (err instanceof ErrorType) {
+    if (errorPredicate(err)) {
       // Transform the error
       return errorHandler(err);
     } else {

--- a/test/types/case-error.ts
+++ b/test/types/case-error.ts
@@ -19,7 +19,7 @@ const rejectNegative = (x: number): Task<number, NoNegativesError> =>
 ;
 
 // isNoNegativesError is a function that tells us if an error is a NoNegativesError
-const isNoNegativesError = <E> (err: E | NoNegativesError): err is NoNegativesError =>
+const isNoNegativesError = (err: any): err is NoNegativesError =>
   err instanceof NoNegativesError
 ;
 

--- a/test/types/case-error.ts
+++ b/test/types/case-error.ts
@@ -7,11 +7,20 @@ import { Task } from '@ts-task/task';
 // It has a `NoNegativesError` public property because TypeScript inference is structural
 class NoNegativesError extends Error {
   NoNegativesError = 'NoNegativesError';
+
+  constructor(public negativeNumber: number) {
+    super(`Ugh! ${negativeNumber} is soooo negative! >:(`);
+  }
 }
 
 // rejectNegative is a function that will return a Task possible rejected with a NoNegativesError
 const rejectNegative = (x: number): Task<number, NoNegativesError> =>
-  x >= 0 ? Task.resolve(x) : Task.reject(new NoNegativesError())
+  x >= 0 ? Task.resolve(x) : Task.reject(new NoNegativesError(x))
+;
+
+// isNoNegativesError is a function that tells us if an error is a NoNegativesError
+const isNoNegativesError = <E> (err: E | NoNegativesError): err is NoNegativesError =>
+  err instanceof NoNegativesError
 ;
 
 // We will tests our `caseError` function with two variables
@@ -30,7 +39,7 @@ const anotherNumber = aNumber // $ExpectType Task<number, NoNegativesError | Unc
 
 // We will also need a function `fixNoNegativesError` that should handle (and resolve)
 // the `NegativesError` case, delegating in `caseError`.
-const fixNoNegativesError = caseError(NoNegativesError, _ => Task.resolve(0));
+const fixNoNegativesError = caseError(isNoNegativesError, _ => Task.resolve(0));
 
 // We try our `fixNoNegativesError` on both Tasks
 const result = aNumber.catch(fixNoNegativesError);


### PR DESCRIPTION
# Description

Changes `caseError` so it now takes a _predicate_ as a _parameter_, instead of a _constructor_. A _predicate_ is a _function_ that takes an `err` of _type_ `E | ErrorToHandle` and returns an `err is ErrorToHandle` (a `boolean`).

## How to test

* `npm t`
* `npm run test:types` 

## Related PRs

**NOTE:** this _PR_ starts from https://github.com/ts-task/utils/pull/5, so merge that one first.