### PR TITLE
feat(tryCatch): added tryCatch method

### DIFF
--- a/src/operators/try-catch.test.ts
+++ b/src/operators/try-catch.test.ts
@@ -1,0 +1,67 @@
+import { Task } from '@ts-task/task';
+import { assertFork, jestAssertNever, jestAssertUntypedNeverCalled } from '../testing-utils';
+import { tryCatch } from './try-catch';
+
+class WrappedError {
+    constructor (public error: Error) {}
+}
+
+describe('tryCatch', () => {
+  it('Should work as map if the function does not throw', cb => {
+    // GIVEN: A resolved task
+    const task = Task.resolve(1);
+
+    // WHEN: We we use a function that does not throw
+    const result = task.pipe(
+      tryCatch(
+          x => x + 1,
+          jestAssertUntypedNeverCalled(cb)
+        )
+    );
+
+    // THEN: The error fn should not be called, and the value is modified
+    result.fork(
+      jestAssertNever(cb),
+      assertFork(cb, x => expect(x).toBe(2))
+    );
+  });
+
+  it('Should not be called if the task was rejected', cb => {
+    // GIVEN: A rejected task
+    const task = Task.reject('fail');
+
+    // WHEN: We we use tryCatch
+    const result = task.pipe(
+      tryCatch(
+          jestAssertUntypedNeverCalled(cb),
+          jestAssertUntypedNeverCalled(cb)
+        )
+    );
+
+    // THEN: The error fn should be called
+    result.fork(
+        assertFork(cb, x => expect(x).toBe('fail')),
+        jestAssertUntypedNeverCalled(cb)
+    );
+  });
+
+  it('Should catch the error with the handler', cb => {
+    // GIVEN: A resolved task
+    const task = Task.resolve(1);
+
+    // WHEN: We we use a function that throws
+    const result = task.pipe(
+      tryCatch(
+          x => {throw new Error('oh no')},
+          err => new WrappedError(err)
+        )
+    );
+
+    // THEN: The error fn should be called with the wrapped error
+    result.fork(
+        assertFork(cb, x => expect(x).toBeInstanceOf(WrappedError)),
+        jestAssertUntypedNeverCalled(cb)
+    );
+  });
+
+});

--- a/src/operators/try-catch.ts
+++ b/src/operators/try-catch.ts
@@ -1,0 +1,21 @@
+import { Task } from '@ts-task/task';
+
+type TryFn<A, B> = (value: A) => B;
+type CatchFn<E> = (err: any) => E;
+
+export function tryCatch<A, B, E> (tryFn: TryFn<A, B>, catchFn: CatchFn<E>) {
+    return function <InnerError>(input: Task<A, InnerError>) {
+        return new Task<B, InnerError | E>((outerResolve, outerReject) => {
+            input.fork(
+                outerReject,
+                val => {
+                    try {
+                        outerResolve(tryFn(val));
+                    } catch (err) {
+                        outerReject(catchFn(err));
+                    }
+                }
+            )
+        });
+    }
+}

--- a/src/ts-task-utils.ts
+++ b/src/ts-task-utils.ts
@@ -4,3 +4,4 @@ export * from './operators/share';
 export * from './is-instance-of';
 export * from './type-helpers';
 export * from './all-properties';
+export * from './operators/try-catch';

--- a/test/types/case-error.ts
+++ b/test/types/case-error.ts
@@ -26,10 +26,10 @@ const isNoNegativesError = (err: any): err is NoNegativesError =>
 // We will tests our `caseError` function with two variables
 // (that is because of a bug we had with the Tasks rejected with only one possible type),
 // one is `aNumber`, whose type is
-const aNumber = rejectNegative(9); // $ExpectType Task<number, NoNegativesError>
+const aNumber = rejectNegative(9 as number); // $ExpectType Task<number, NoNegativesError>
 
 // ...the other one is `anotherNumber`, whose type is
-const anotherNumber = aNumber // $ExpectType Task<number, NoNegativesError | UnknownError>
+const anotherNumber = aNumber // $ExpectType Task<number, UnknownError | NoNegativesError>
   .map(x => x)
 ;
 

--- a/test/types/try-catch.ts
+++ b/test/types/try-catch.ts
@@ -1,0 +1,24 @@
+import { tryCatch } from '@ts-task/utils';
+import { Task } from '@ts-task/task';
+
+const t1 = Task.resolve(1).pipe(
+  tryCatch(
+    x => x + 1,
+    err => {
+      // Try Catch is not typed, so the err can be anything
+      err; // $ExpectType any
+      return 'some error';
+    }
+  )
+);
+
+// And the value is whatever we return from the handler
+t1; // $ExpectType Task<number, string | UnknownError>
+
+const t2 = Task.resolve('{some invalid json').pipe(
+  tryCatch(
+    str => JSON.parse(str),
+    err => err as SyntaxError
+  )
+);
+t2; // $ExpectType Task<any, UnknownError | SyntaxError>

--- a/test/types/type-helpers.ts
+++ b/test/types/type-helpers.ts
@@ -5,10 +5,10 @@ const t1 = Task.resolve(1);
 type T1 = TaskValue<typeof t1>;
 
 // $ExpectType number
-const n: T1 = 1;
+const n: T1 = 1 as number;
 
 const e1 = Task.reject('oh no');
 type E1 = TaskError<typeof e1>;
 
 // $ExpectType string
-const s: E1 = 'oh no';
+const s: E1 = 'oh no' as string;


### PR DESCRIPTION
### `tryCatch`

`tryCatch(mapFn, handler)`

`tryCatch` works like map but inside a try catch block. If the function throws the handler is executed with the thrown error.

```typescript
import { Task } from '@ts-task/task';
import { tryCatch } from '@ts-task/utils';

// Try Catch can be useful to type the error
Task.resolve('{some invalid json').pipe(
  tryCatch(
    str => JSON.parse(str),
    err => err as SyntaxError
  )
) // $ExpectType Task<any, UnknownError | SyntaxError>

// Or even wrap it in another object
class ParsingCustomError {
  constructor (public error: SyntaxError) {
    this.message = 'custom message';
  }
}

Task.resolve('{some invalid json').pipe(
  tryCatch(
    str => JSON.parse(str),
    err => new ParsingCustomError(err)
  )
) // $ExpectType Task<any, UnknownError | ParsingCustomError>

```